### PR TITLE
ページタイトルをフル名称にする

### DIFF
--- a/src/components/pek2024/Logo.astro
+++ b/src/components/pek2024/Logo.astro
@@ -6,7 +6,7 @@ import { Picture } from 'astro:assets';
   <Picture
     src={import('~/assets/images/pek2024/pek2024_horizontal.png')}
     class="w-20"
-    alt="PEK2024 logo"
+    alt="Platform Engineering Kaigi 2024 logo"
     widths={[2000]}
   />
 </span>

--- a/src/layouts/pek2024/BaseLayout.astro
+++ b/src/layouts/pek2024/BaseLayout.astro
@@ -16,18 +16,18 @@ const ogpImageURL = new URL('/pek2024_ogp.png', canonicalURL);
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <meta property="og:title" content="pek2024" />
+    <meta property="og:title" content="Platform Engineering Kaigi 2024 " />
     <meta property="og:type" content="website" />
     <meta property="og:description" content="Platform Engineering Kaigi 2024" />
     <meta property="og:image" content={ogpImageURL} />
     <meta property="og:url" content={Astro.request.url} />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="pek2024" />
+    <meta name="twitter:title" content="Platform Engineering Kaigi 2024 " />
     <meta name="twitter:description" content="Platform Engineering Kaigi 2024" />
     <meta name="twitter:image" content={ogpImageURL} />
 
     <CustomStyles />
-    <title>pek2024</title>
+    <title>Platform Engineering Kaigi 2024</title>
     <link rel="icon" href="/pek2024_trademark.ico" type="image/x-icon" />
   </head>
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -11,7 +11,7 @@ const imageSrc = import('~/assets/images/CNIA-404.png');
   <section class="flex items-center h-full p-16">
     <div class="container flex flex-col items-center justify-center px-5 mx-auto my-8">
       <div class="max-w-md text-center flex flex-col items-center space-y-4">
-        <Picture src={imageSrc} width={800} height={600} alt="PEK2024 logo" widths={[2000]} />
+        <Picture src={imageSrc} width={800} height={600} alt="Platform Engineering Kaigi 2024 logo" widths={[2000]} />
         <div>
           <h3 class="text-primary mt-2 mb-4 text-xl">PAGE NOT FOUND</h3>
           <p class="text-2xl font-semibold md:text-2xl">お探しのページが見つかりませんでした。</p>

--- a/src/pages/pek2024/index.astro
+++ b/src/pages/pek2024/index.astro
@@ -12,6 +12,7 @@ import Update from '~/components/pek2024/Update.astro';
 <Layout>
   <Hero />
 
+  <a id="update"></a>
   <Update
     highlight="News"
     title="お知らせ"
@@ -33,7 +34,7 @@ import Update from '~/components/pek2024/Update.astro';
     title="日本初 Platform Engineeringの祭典"
     image={{
       src: import('~/assets/images/pek2024/pek2024_trademark.png'),
-      alt: 'PEK2024 Logo',
+      alt: 'Platform Engineering Kaigi 2024 Logo',
     }}
   >
     <Fragment slot="content">
@@ -77,6 +78,7 @@ import Update from '~/components/pek2024/Update.astro';
     }}
   />
 
+  <a id="faq"></a>
   <FAQ
     highlight="FAQ"
     title="よくある質問"


### PR DESCRIPTION
pek2024になってた部分を`Platform Engineering Kaigi 2024` に修正

---

<img width="364" alt="image" src="https://github.com/cniajp/cnia.io/assets/49088864/89d41b5b-d50d-4c5d-8122-2fad85cd225c">

<img width="523" alt="image" src="https://github.com/cniajp/cnia.io/assets/49088864/35d6b90b-1d04-44e1-b2dd-cee9f7803031">
