### PR TITLE
ブロンズスポンサー募集終了 & お知らせの最大表示数調整

### DIFF
--- a/src/components/pek2024/Sponsors.astro
+++ b/src/components/pek2024/Sponsors.astro
@@ -1,5 +1,4 @@
 ---
-import Icon from 'astro-icon';
 import { Picture } from 'astro:assets';
 import { sponsorsData, rankGridSettings } from '~/pek2024_data';
 
@@ -29,30 +28,15 @@ function generateGridClass(rank) {
       isRecPeriod ? (
         <div class="container mx-auto max-w-xl lg:max-w-2xl">
           <p>
-            現在 Platform Engineering Kaigi 2024
-            を応援していただける企業スポンサー様（ブロンズ）を追加募集しております。
-          </p>
-          <p>
             <strong>
-              ※ 2024/03/04 18:00 を持ちましてプラチナ、ゴールド、シルバー 、ランチスポンサー様の募集は締め切りました。
+              ※ 2024/04/01 18:00 を持ちましてすべてのスポンサー様の募集を締め切りました。
               <br />
+              多数のご応募ありがとうございました。
             </strong>
           </p>
           <br />
-
-          <p>企業スポンサー様として参加いただき貴社をPRしませんか？</p>
-          <p>スポンサーランクに応じた特典、詳細につきましては以下のスポンサー様向け資料をご覧ください。</p>
-          <br />
-          <div class="sponsor-documents items-center justify-center">
-            <a
-              href="https://pfem.notion.site/Platform-Engineering-Kaigi-d7d26e7452e14f7cbe9145510438e119?pvs=4"
-              target="_blank"
-              class="flex items-center"
-            >
-              <Icon name="tabler:book-2" class="w-4 h-4 mr-2 md:text-left" />
-              <p class="mb-0">スポンサー様向け資料</p>
-            </a>
-          </div>
+          <p>現在 ご応募いただいたスポンサー様の掲載準備を行っております。</p>
+          <p>掲載まで今しばらくお待ちいただけますようお願い申し上げます。</p>
         </div>
       ) : (
         Object.entries(sponsorsData).map(([rank, sponsors]) => (

--- a/src/components/pek2024/Update.astro
+++ b/src/components/pek2024/Update.astro
@@ -15,6 +15,8 @@ export interface UpdatesProps {
 }
 
 const { highlight, title, items } = Astro.props as UpdatesProps;
+const visibleItems = items.slice(0, 5);
+const hiddenItems = items.length > 5 ? items.slice(5) : [];
 ---
 
 <section class="bg-slate-100 py-10 md:py-14">
@@ -25,7 +27,7 @@ const { highlight, title, items } = Astro.props as UpdatesProps;
     </div>
     <div class="space-y-1 px-4">
       {
-        items.map((update) => (
+        visibleItems.map((update) => (
           <div class="update-item">
             <p class="text-lg font-medium flex items-center">
               <span class="font-bold mr-6">{update.date}</span>
@@ -41,13 +43,61 @@ const { highlight, title, items } = Astro.props as UpdatesProps;
                   <Icon name="tabler:link" class="w-4 h-4 ml-2" />
                 </a>
               )}
-              {!update.link && !update.internalLink && (
-                <span>{update.text}</span>
-              )}
+              {!update.link && !update.internalLink && <span>{update.text}</span>}
             </p>
           </div>
         ))
       }
+      {
+        hiddenItems.length > 0 && (
+          <div>
+            <div id="hiddenItems" class="hidden">
+              {hiddenItems.map((update) => (
+                <div class="update-item">
+                  <p class="text-lg font-medium flex items-center">
+                    <span class="font-bold mr-6">{update.date}</span>
+                    {update.link && (
+                      <a href={update.link} target="_blank" rel="noopener noreferrer" class="flex items-center">
+                        {update.text}
+                        <Icon name="tabler:external-link" class="w-4 h-4 ml-2" />
+                      </a>
+                    )}
+                    {update.internalLink && (
+                      <a href={update.internalLink} class="flex items-center">
+                        {update.text}
+                        <Icon name="tabler:link" class="w-4 h-4 ml-2" />
+                      </a>
+                    )}
+                    {!update.link && !update.internalLink && <span>{update.text}</span>}
+                  </p>
+                </div>
+              ))}
+            </div>
+            <div id="toggleButton" class="py-2 px-8 font-semibold text-right cursor-pointer">
+              Show all news
+            </div>
+          </div>
+        )
+      }
     </div>
   </div>
 </section>
+
+<script>
+  const toggleButton = document.getElementById('toggleButton');
+  const hiddenItems = document.getElementById('hiddenItems');
+
+  if (toggleButton !== null && hiddenItems !== null) {
+    toggleButton.addEventListener('click', () => {
+      if (hiddenItems.classList.contains('hidden')) {
+        hiddenItems.classList.remove('hidden');
+        hiddenItems.classList.add('block');
+        toggleButton.innerText = 'Close';
+      } else {
+        hiddenItems.classList.remove('block');
+        hiddenItems.classList.add('hidden');
+        toggleButton.innerText = 'Show all news';
+      }
+    });
+  }
+</script>

--- a/src/pages/pek2024/index.astro
+++ b/src/pages/pek2024/index.astro
@@ -34,6 +34,10 @@ const blogPosts = allPosts.map((post) => {
 });
 const news = [
   {
+    date: '2024/04/01',
+    text: 'ブロンズスポンサーの追加受付を終了しました',
+  },
+  {
     date: '2024/03/22',
     text: 'CFPを開始しました',
     link: 'https://www.cnia.io/pek2024/sessions/guidance',


### PR DESCRIPTION
## 概要

- ブロンズスポンサー募集終了
- お知らせが長くなってきたので最大お知らせ数を5つに、6件目以降はトグル表示