### PR TITLE
セッション詳細ページを採択されたセッションのみに絞る

### DIFF
--- a/src/components/pek2024/SessionList.astro
+++ b/src/components/pek2024/SessionList.astro
@@ -6,7 +6,7 @@ import { type PEK2024ProposalList } from '../../types';
 const { data } = await axios.get<PEK2024ProposalList>(
   'https://fortee.jp/platform-engineering-kaigi-2024/api/proposals'
 );
-const sessionsList = data.proposals;
+const sessionsList = data.proposals.filter((proposal) => proposal.accepted);
 ---
 
 <section class="py-10 md:py-14">

--- a/src/pages/pek2024/sessions/[id].astro
+++ b/src/pages/pek2024/sessions/[id].astro
@@ -17,10 +17,12 @@ import { type PEK2024ProposalList } from '../../../types';
 export async function getStaticPaths() {
   const { data } = await axios.get<PEK2024ProposalList>('https://fortee.jp/platform-engineering-kaigi-2024/api/proposals');
   const sessionsList = data.proposals;
-  return sessionsList.map((session) => ({
-    params: { id: session.uuid.toString() },
-    props: { session },
-  }));
+  return sessionsList
+    .filter((session) => session.accepted === true)
+    .map((session) => ({
+      params: { id: session.uuid.toString() },
+      props: { session },
+    }));
 }
 
 const { session } = Astro.props;


### PR DESCRIPTION
全ての CfP の詳細ページをビルドすると時間がかかるため、採択されたセッションのみに絞って、ビルド時間を短くしました。