### PR TITLE
セッションの meta tag に入れる値を修正

### DIFF
--- a/src/pages/pek2024/sessions/[id].astro
+++ b/src/pages/pek2024/sessions/[id].astro
@@ -51,7 +51,7 @@ const talkAbstract = getTalkAbstract(session);
 <Layout
   meta={{
     title: sessionExists ? session.title : 'セッションが見つかりませんでした',
-    description: sessionExists ? session.abstract : 'セッションの概要が見つかりませんでした',
+    description: sessionExists ? talkAbstract : 'セッションの概要が見つかりませんでした',
   }}
 >
   <main>


### PR DESCRIPTION
pek のセッション詳細ページで、 meta の description に fortee の abstract をそのまま入れていたので、整形済みのデータを入れるように修正。