### PR TITLE
サブディレクトリに sitemap を置く custom integration を作成

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -35,7 +35,10 @@ export default defineConfig({
         applyBaseStyles: false,
       },
     }),
-    sitemap(),
+    sitemap({
+      // pek2024 は別ディレクトリに出力するため除外
+      filter: (page) => !page.startsWith(SITE.origin + '/pek2024')
+    }),
     subDirSitemap({outputDir: "pek2024", basePath: "pek2024"}),
     mdx(),
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,7 @@ import mdx from '@astrojs/mdx';
 import partytown from '@astrojs/partytown';
 import { readingTimeRemarkPlugin } from './src/utils/frontmatter.mjs';
 import icon from "astro-icon";
+import {subDirSitemap} from "./src/integrations/sub-dir-sitemap";
 
 import { SITE } from './src/config.mjs';
 
@@ -35,6 +36,7 @@ export default defineConfig({
       },
     }),
     sitemap(),
+    subDirSitemap({outputDir: "pek2024", basePath: "pek2024"}),
     mdx(),
 
     ...whenExternalScripts(() =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "axios": "^1.6.8",
         "cheerio": "^1.0.0-rc.12",
         "install": "^0.13.0",
+        "sitemap": "^8.0.0",
         "tiny-invariant": "^1.3.1"
       },
       "devDependencies": {
@@ -661,6 +662,31 @@
         "sitemap": "^7.1.1",
         "stream-replace-string": "^2.0.0",
         "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@astrojs/sitemap/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "dev": true
+    },
+    "node_modules/@astrojs/sitemap/node_modules/sitemap": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.2.tgz",
+      "integrity": "sha512-ARCqzHJ0p4gWt+j7NlU5eDlIO9+Rkr/JhPFZKKQ1l5GCus7rJH4UdrlVAh0xC/gDS/Qir2UMxqYNHtsKr2rpCw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^17.0.5",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "sitemap": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=5.6.0"
       }
     },
     "node_modules/@astrojs/tailwind": {
@@ -2767,7 +2793,6 @@
       "version": "20.12.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.11.tgz",
       "integrity": "sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==",
-      "devOptional": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2776,7 +2801,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3155,8 +3179,7 @@
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -11474,8 +11497,7 @@
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
@@ -11633,10 +11655,9 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "node_modules/sitemap": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.1.tgz",
-      "integrity": "sha512-mK3aFtjz4VdJN0igpIJrinf3EO8U8mxOPsTBzSsy06UtjZQJ3YY3o3Xa7zSc5nMqcMrRwlChHZ18Kxg0caiPBg==",
-      "dev": true,
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.0.tgz",
+      "integrity": "sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==",
       "dependencies": {
         "@types/node": "^17.0.5",
         "@types/sax": "^1.2.1",
@@ -11647,15 +11668,14 @@
         "sitemap": "dist/cli.js"
       },
       "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=5.6.0"
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/sitemap/node_modules/@types/node": {
       "version": "17.0.45",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "dev": true
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -12515,8 +12535,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "devOptional": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unherit": {
       "version": "3.0.1",
@@ -14091,6 +14110,26 @@
         "sitemap": "^7.1.1",
         "stream-replace-string": "^2.0.0",
         "zod": "^3.22.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "17.0.45",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+          "dev": true
+        },
+        "sitemap": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.2.tgz",
+          "integrity": "sha512-ARCqzHJ0p4gWt+j7NlU5eDlIO9+Rkr/JhPFZKKQ1l5GCus7rJH4UdrlVAh0xC/gDS/Qir2UMxqYNHtsKr2rpCw==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^17.0.5",
+            "@types/sax": "^1.2.1",
+            "arg": "^5.0.0",
+            "sax": "^1.2.4"
+          }
+        }
       }
     },
     "@astrojs/tailwind": {
@@ -15370,7 +15409,6 @@
       "version": "20.12.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.11.tgz",
       "integrity": "sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==",
-      "devOptional": true,
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -15379,7 +15417,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -15634,8 +15671,7 @@
     "arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "argparse": {
       "version": "2.0.1",
@@ -21479,8 +21515,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "section-matter": {
       "version": "1.0.0",
@@ -21604,10 +21639,9 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "sitemap": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.1.tgz",
-      "integrity": "sha512-mK3aFtjz4VdJN0igpIJrinf3EO8U8mxOPsTBzSsy06UtjZQJ3YY3o3Xa7zSc5nMqcMrRwlChHZ18Kxg0caiPBg==",
-      "dev": true,
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.0.tgz",
+      "integrity": "sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==",
       "requires": {
         "@types/node": "^17.0.5",
         "@types/sax": "^1.2.1",
@@ -21618,8 +21652,7 @@
         "@types/node": {
           "version": "17.0.45",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-          "dev": true
+          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
         }
       }
     },
@@ -22246,8 +22279,7 @@
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "devOptional": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "unherit": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "axios": "^1.6.8",
     "cheerio": "^1.0.0-rc.12",
     "install": "^0.13.0",
+    "sitemap": "^8.0.0",
     "tiny-invariant": "^1.3.1"
   }
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Disallow:
+Sitemap: https://www.cnia.io/sitemap-index.xml
+Sitemap: https://www.cnia.io/pek2024/sitemap.xml

--- a/src/integrations/sub-dir-sitemap.ts
+++ b/src/integrations/sub-dir-sitemap.ts
@@ -1,0 +1,37 @@
+import type { AstroIntegration } from "astro";
+import { SitemapStream } from "sitemap";
+import { createWriteStream } from "fs";
+import { fileURLToPath } from "url";
+
+export const subDirSitemap = (options: {outputDir: string, basePath: string}): AstroIntegration => {
+  const { outputDir, basePath } = options;
+  return {
+    name: "cnia.io/sitemap",
+    hooks: {
+      "astro:build:done": async ({ dir, pages }) => {
+        const hostname = "https://www.cnia.io/";
+        const sms = new SitemapStream({
+          hostname,
+        });
+        const excludeSlugs = ["404"];
+        const destinationDir = fileURLToPath(dir);
+        const outputFileName =  outputDir ? outputDir + "/sitemap.xml" : "sitemap.xml";
+
+        pages.forEach(({ pathname }) => {
+          const slug = pathname.slice(0, -1);
+          if (excludeSlugs.includes(slug)) {
+            return;
+          }
+          if (basePath !== undefined && pathname.startsWith(basePath)) {
+            console.log(pathname)
+            sms.write(hostname + pathname);
+          }
+        });
+        sms.end();
+        sms.pipe(createWriteStream(destinationDir + outputFileName));
+
+        console.log(`%s${outputFileName} is generated!\n`, "\x1b[32m");
+      },
+    },
+  };
+};

--- a/src/integrations/sub-dir-sitemap.ts
+++ b/src/integrations/sub-dir-sitemap.ts
@@ -15,14 +15,14 @@ export const subDirSitemap = (options: {outputDir: string, basePath: string}): A
         });
         const excludeSlugs = ["404"];
         const destinationDir = fileURLToPath(dir);
-        const outputFileName =  outputDir ? outputDir + "/sitemap.xml" : "sitemap.xml";
+        const outputFileName =  outputDir + "/sitemap.xml";
 
         pages.forEach(({ pathname }) => {
           const slug = pathname.slice(0, -1);
           if (excludeSlugs.includes(slug)) {
             return;
           }
-          if (basePath !== undefined && pathname.startsWith(basePath)) {
+          if (pathname.startsWith(basePath)) {
             sms.write(hostname + pathname);
           }
         });

--- a/src/integrations/sub-dir-sitemap.ts
+++ b/src/integrations/sub-dir-sitemap.ts
@@ -23,7 +23,6 @@ export const subDirSitemap = (options: {outputDir: string, basePath: string}): A
             return;
           }
           if (basePath !== undefined && pathname.startsWith(basePath)) {
-            console.log(pathname)
             sms.write(hostname + pathname);
           }
         });


### PR DESCRIPTION
サブディレクトリに sitemap を置く custom integration を作成しました。

PEK2024 の search console が `/pek2024` 配下の sitemap しか登録できませんでした。
astro が提供している sitemap の integration は、sitemap の置き場所などを指定できなかったため自作しました。
slack でのやり取り
https://pfemjp.slack.com/archives/C06DP239M43/p1716468610541219?thread_ts=1716468054.789599&cid=C06DP239M43

参考サイト
https://shinobiworks.com/blog/641/