### PR TITLE
次回PFEMの開催情報を更新

### DIFF
--- a/src/pages/pfem/index.astro
+++ b/src/pages/pfem/index.astro
@@ -89,10 +89,10 @@ const sortedSessions = sessions.sort((a, b) => {
     highlight="Upcoming"
     items={[
       {
-        event: 'Platform Engineering Meetup #8',
-        date: '2024/04/19',
-        place: '大阪',
-        connpassUrl: 'https://platformengineering.connpass.com/event/310994/',
+        event: 'Platform Engineering Meetup #9',
+        date: '2024/07/04',
+        place: '東京',
+        connpassUrl: 'https://platformengineering.connpass.com/event/322020/',
       },
     ]}
   />


### PR DESCRIPTION
下記のように修正しました。
<img width="611" alt="スクリーンショット 2024-06-28 0 40 03" src="https://github.com/cniajp/cnia.io/assets/12871716/c69da55b-9ff8-418f-8bbe-6d993077ebca">
