### PR TITLE
PEK top ページをイベント終了後のレイアウトに変更

### DIFF
--- a/src/components/pek2024/Hero.astro
+++ b/src/components/pek2024/Hero.astro
@@ -44,11 +44,14 @@ import logoLiteral from '~/assets/images/pek2024/pek2024_literal.svg';
               <div class="mx-auto">
                 <p class="flex justify-center text-base md:text-base font-medium">HASHTAG: <strong>#PEK2024</strong></p>
               </div>
+              <div class="mx-auto">
+                <p class="flex justify-center text-base font-bold">本イベントは終了しました</p>
+              </div>
               <div class="flex flex-col items-center justify-center mt-8">
                 <a
                   rel="noopener noreferrer"
-                  href="/pek2024/watch"
-                  class="btn btn-flat ml-4 mb-2 rounded-md text-sm">視聴ページへ移動する</a
+                  href="/pek2024/sessions"
+                  class="btn btn-flat ml-4 mb-2 rounded-md text-sm">セッションを見る</a
                 >
               </div>
             </div>

--- a/src/components/pek2024/Note.astro
+++ b/src/components/pek2024/Note.astro
@@ -19,7 +19,7 @@ const { highlight, title, subtitle } = Astro.props;
   <div class="mx-auto max-w-7xl p-4 md:px-8 font-medium">
     <div class="container mx-auto max-w-xl lg:max-w-2xl">
       <p class="md:text-2xl text-center">
-        <strong>日本初！</strong>TeamTopologiesの著者、マニュエル・パイス氏による有料特別トレーニング開催決定！
+        <strong>日本初！</strong>TeamTopologiesの著者、マニュエル・パイス氏による有料特別トレーニングを開催しました
       </p>
 
       <div class="flex flex-col items-center justify-center pt-8">

--- a/src/pages/pek2024/blog/[...blog].astro
+++ b/src/pages/pek2024/blog/[...blog].astro
@@ -2,7 +2,6 @@
 import Layout from '~/layouts/pek2024/PageLayout.astro';
 import { getCollection } from 'astro:content';
 import { Image } from 'astro:assets';
-import TeamTopologiesSeminarBanner from '~/components/pek2024/TeamTopologiesSeminarBanner.astro';
 
 export async function getStaticPaths() {
   const blogEntries = await getCollection('pek2024-blog', ({ data }) => {
@@ -27,9 +26,6 @@ if (post.data.author?.icon && !teamMemberImages[post.data.author.icon]) {
   imagePath: post.data.image
 }}>
   <section class="px-4 py-16 sm:px-6 mx-auto lg:px-8 lg:py-20 max-w-4xl">
-    <div class="flex flex-col items-center mb-4">
-      <TeamTopologiesSeminarBanner/>
-    </div>
     <h1 class="font-bold font-heading text-4xl md:text-5xl leading-tighter tracking-tighter">{post.data.title}</h1>
     <div class="my-4">
       <div class="flex flex-col md:flex-row">

--- a/src/pages/pek2024/blog/index.astro
+++ b/src/pages/pek2024/blog/index.astro
@@ -4,7 +4,6 @@ import { getCollection } from 'astro:content';
 import { Image } from 'astro:assets';
 import type { ImageMetadata } from 'astro';
 import defaultThumbnail from '~/assets/images/pek2024/pek2024_horizontal.png';
-import TeamTopologiesSeminarBanner from '~/components/pek2024/TeamTopologiesSeminarBanner.astro';
 
 const allPosts = await getCollection('pek2024-blog', ({ data }) => {
   return data.draft !== true;
@@ -29,9 +28,6 @@ const getUrl = (slug: string) => `/pek2024/blog/${slug}`;
     description: 'Platform Engineering Kaigi 2024に関する情報を発信しています。',
   }}
 >
-  <div class="flex justify-center mt-4">
-    <TeamTopologiesSeminarBanner />
-  </div>
   <section class="bg-white">
     <div class="py-8 px-4 mx-auto max-w-screen-xl lg:px-6">
       <div class="mx-auto max-w-screen-sm text-center mb-8">

--- a/src/pages/pek2024/index.astro
+++ b/src/pages/pek2024/index.astro
@@ -79,16 +79,6 @@ const news = [
   <Hero />
 
   <a id="update"></a>
-  <div class="py-10 bg-slate-100">
-    <div class="mb-10 md:mx-auto text-center md:mb-12 max-w-3xl">
-      <p class="text-base dark:text-blue-200 font-semibold tracking-wide uppercase">Staff Recruitment</p>
-      <h2 class="text-4xl md:text-5xl font-bold leading-tighter tracking-tighter mb-4">当日スタッフ募集</h2>
-    </div>
-    <div class="flex flex-col items-center justify-center">
-      <p>応募を多数いただきましたので本募集は終了します。</p>
-      <p>ありがとうございました。</p>
-    </div>
-  </div>
 
   <Update highlight="News" title="お知らせ" items={news} />
   {blogPosts.length > 0 && <Update highlight="Blog" title="ブログ" items={blogPosts.slice(0, 5)} />}

--- a/src/pages/pek2024/schedules/index.astro
+++ b/src/pages/pek2024/schedules/index.astro
@@ -1,7 +1,6 @@
 ---
 import Layout from '~/layouts/pek2024/PageLayout.astro';
 import Schedule from '~/components/pek2024/Schedule.astro';
-import TeamTopologiesSeminarBanner from '~/components/pek2024/TeamTopologiesSeminarBanner.astro';
 
 ---
 <Layout
@@ -10,9 +9,6 @@ import TeamTopologiesSeminarBanner from '~/components/pek2024/TeamTopologiesSemi
     description: 'Platform Engineering Kaigi 2024 のタイムテーブルです。',
   }}
 >
-  <div class="flex flex-col items-center pt-4 bg-slate-100">
-    <TeamTopologiesSeminarBanner/>
-  </div>
   <Schedule />
 </Layout>
 

--- a/src/pages/pek2024/sessions/[id].astro
+++ b/src/pages/pek2024/sessions/[id].astro
@@ -8,7 +8,6 @@ import SocialShare from '../../../components/common/SocialShare.astro';
 import { fetchTags } from '../../../utils/fetchTags';
 import { getAffiliation, getJobTitle, getSpeakerProfile, getTalkAbstract } from '../../../utils/pek2024/fortee';
 import { type PEK2024ProposalList } from '../../../types';
-import TeamTopologiesSeminarBanner from '~/components/pek2024/TeamTopologiesSeminarBanner.astro';
 import { Icon } from 'astro-icon/components';
 
 export async function getStaticPaths() {
@@ -60,9 +59,6 @@ const talkAbstract = getTalkAbstract(session.abstract);
       sessionExists && (
         <div>
           <div class="mt-14 mb-10 text-left max-w-3xl mx-auto px-4">
-            <div class="flex flex-col items-center mb-4">
-              <TeamTopologiesSeminarBanner/>
-            </div>
             <h2 class="text-2xl md:text-3xl font-bold leading-tight tracking-tight">{session.title}</h2>
 
             <div class="flex flex-wrap items-center mt-2">

--- a/src/pages/pfem/sessions/[...session].astro
+++ b/src/pages/pfem/sessions/[...session].astro
@@ -2,7 +2,6 @@
 import { getCollection } from 'astro:content';
 import Layout from '~/layouts/CNIA/PageLayout.astro';
 import SessionCard from '~/components/pfem/SessionCard.astro';
-import TeamTopologiesSeminarBanner from '~/components/pek2024/TeamTopologiesSeminarBanner.astro';
 
 export async function getStaticPaths() {
   const sessions = await getCollection('pfem-session', ({ data }) => {
@@ -38,9 +37,6 @@ const relatedSessions = (
   description: session.data.description,
   image: session.data.image,
 }}> 
-  <div class="flex flex-col items-center">
-    <TeamTopologiesSeminarBanner/>
-  </div>
   <div class="flex justify-center">
     <iframe
       class="rounded-lg mx-auto max-w-xs md:max-w-3xl"

--- a/src/pages/pfem/sessions/index.astro
+++ b/src/pages/pfem/sessions/index.astro
@@ -2,7 +2,6 @@
 import { getCollection } from 'astro:content';
 import Layout from '~/layouts/CNIA/PageLayout.astro';
 import SessionCard from '~/components/pfem/SessionCard.astro'
-import TeamTopologiesSeminarBanner from '~/components/pek2024/TeamTopologiesSeminarBanner.astro';
 
 const allSessionss = await getCollection('pfem-session', ({ data }) => {
     return data.draft !== true;
@@ -28,9 +27,6 @@ const sortedSessions = allSessionss.sort((a, b) => {
 }}
 >
   <section class="text-gray-800">
-    <div class="flex flex-col items-center">
-      <TeamTopologiesSeminarBanner/>
-    </div>
     <div class="py-8 px-4 mx-auto max-w-screen-xl lg:px-6">
       <div class="mx-auto max-w-screen-sm text-center mb-8">
         <h2 class="mb-4 text-3xl lg:text-4xl tracking-tight font-extrabold text-gray-900">Sessions</h2>

--- a/src/pek2024_data.js
+++ b/src/pek2024_data.js
@@ -14,6 +14,10 @@ export const headerData = {
       href: '/pek2024#about',
     },
     {
+      text: 'SCHEDULE',
+      href: '/pek2024/schedules',
+    },
+    {
       text: 'SESSIONS',
       href: '/pek2024/sessions',
     },

--- a/src/pek2024_data.js
+++ b/src/pek2024_data.js
@@ -14,8 +14,8 @@ export const headerData = {
       href: '/pek2024#about',
     },
     {
-      text: 'SCHEDULE',
-      href: '/pek2024/schedules',
+      text: 'SESSIONS',
+      href: '/pek2024/sessions',
     },
     {
       text: 'SPEAKERS',


### PR DESCRIPTION
PEK top ページをイベント終了後のレイアウトに変更しました。
- [x] イベント終了文言を Hero に追加
- [x] 視聴ページのボタンをセッションページへ変更
- [x] 当日スタッフ募集セクションの削除
- [x] チートポセミナーのセクションの文言変更
- [x] 色々なページに掲載していたチートポセミナーのバナーを削除
- [x] ヘッダーのメニューに sessions を追加