### PR TITLE
PEK2024 のセッションページに youtube の embed とスライドのリンクを追加

### DIFF
--- a/src/pages/pek2024/sessions/[id].astro
+++ b/src/pages/pek2024/sessions/[id].astro
@@ -9,6 +9,7 @@ import { fetchTags } from '../../../utils/fetchTags';
 import { getAffiliation, getJobTitle, getSpeakerProfile, getTalkAbstract } from '../../../utils/pek2024/fortee';
 import { type PEK2024ProposalList } from '../../../types';
 import TeamTopologiesSeminarBanner from '~/components/pek2024/TeamTopologiesSeminarBanner.astro';
+import { Icon } from 'astro-icon/components';
 
 export async function getStaticPaths() {
   const { data } = await axios.get<PEK2024ProposalList>(
@@ -100,10 +101,10 @@ const talkAbstract = getTalkAbstract(session.abstract);
                 <div class="flex-auto">
                   <a href={session.slide_url as string} target="_blank" rel="noopener noreferrer">
                     <button
-                      class="bg-themeColor-blue hover:bg-blue-500 text-white font-bold py-2 px-4 rounded"
-                      style="transition: all 0.3s ease;"
+                      class="bg-themeColor-orange hover:bg-themeColor-yellow text-white font-bold py-2 px-4 rounded inline-flex items-center"
                     >
                       スライドを見る
+                      <Icon name="tabler:external-link" class="w-4 h-4 ml-2" />
                     </button>
                   </a>
                 </div>

--- a/src/pages/pek2024/sessions/[id].astro
+++ b/src/pages/pek2024/sessions/[id].astro
@@ -79,14 +79,13 @@ const talkAbstract = getTalkAbstract(session.abstract);
               })}
             </div>
 
-            {'videoUrl' in session && session.videoUrl && (
+            {'video_url' in session && session.video_url && (
               <div class="relative flex flex-col min-w-0 break-words w-full mb-2">
-                <div class="px-4 pt-5 flex-auto">
-                  <div class="text-sm">登壇動画</div>
+                <div class="flex-auto">
                   <div>
                     <iframe
                       class="aspect-video min-w-2xl w-full static bottom-0"
-                      src={(session.videoUrl ?? '').toString()}
+                      src={(session.video_url ?? '').toString()}
                       title="YouTube video player"
                       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                       allowfullscreen
@@ -96,18 +95,17 @@ const talkAbstract = getTalkAbstract(session.abstract);
               </div>
             )}
 
-            {'documentUrl' in session && session.documentUrl && (
+            {'slide_url' in session && session.slide_url && (
               <div class="relative flex flex-col min-w-0 break-words w-full mb-2">
-                <div class="px-4 pt-5 flex-auto">
-                  <div class="text-sm">登壇資料</div>
-                  <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-                    <iframe
-                      style="position: absolute; top:0; left: 0; width: 100%; height: 100%; border:0;"
-                      src={(session.documentUrl ?? '').toString()}
-                      title="Document viewer"
-                      allowfullscreen
-                    />
-                  </div>
+                <div class="flex-auto">
+                  <a href={session.slide_url as string} target="_blank" rel="noopener noreferrer">
+                    <button
+                      class="bg-themeColor-blue hover:bg-blue-500 text-white font-bold py-2 px-4 rounded"
+                      style="transition: all 0.3s ease;"
+                    >
+                      スライドを見る
+                    </button>
+                  </a>
                 </div>
               </div>
             )}
@@ -178,6 +176,7 @@ const talkAbstract = getTalkAbstract(session.abstract);
                 <p class="mt-2 text-sm whitespace-pre-line">{speakerProfile}</p>{' '}
               </div>
             </div>
+
 
             <SocialShare
               url={Astro.request.url}


### PR DESCRIPTION
PEK2024 のセッションページに youtube の embed と登壇資料のリンクを追加しました。
各セッションの 動画と登壇資料の url は、 fortee から設定できたので、それを使うようにします。

登壇資料は embed にするか迷いましたが、動画があれば slide まで embed しなくてよさそうに思ったので、一旦 link だけするようにしました。

とりあえずマニュエルさんのセッションだけ動画と登壇資料を追加しました。
`/pek2024/sessions/b425872b-4a02-49ab-858a-3fffeebe866d` 

### TODO
- [x] fortee の各セッションに動画と登壇資料のURLを追加