### PR TITLE
ヘッダーリンクの修正とCFP応募要項の追加

### DIFF
--- a/src/components/pek2025/Header.astro
+++ b/src/components/pek2025/Header.astro
@@ -5,10 +5,10 @@
 <header class="container mx-auto py-4 px-4 ">
   <div class="flex justify-between items-center">
     <nav class="flex space-x-6">
-      <a href="#about" class="text-pek2025-primary-700 hover:text-pek2025-primary-600 font-medium">
+      <a href="/pek2025#about" class="text-pek2025-primary-700 hover:text-pek2025-primary-600 font-medium">
         概要
       </a>
-      <a href="#sponsors" class="text-pek2025-primary-700 hover:text-pek2025-primary-600 font-medium">
+      <a href="/pek2025#sponsors" class="text-pek2025-primary-700 hover:text-pek2025-primary-600 font-medium">
         スポンサー募集
       </a>
     </nav>

--- a/src/pages/pek2025/sessions/guidance.astro
+++ b/src/pages/pek2025/sessions/guidance.astro
@@ -1,0 +1,241 @@
+---
+import Layout from '../../../layouts/pek2025/PageLayout.astro';
+---
+
+<Layout
+  meta={{
+    title: 'PEK2025 CFP応募要項',
+    description: 'Platform Engineering Kaigi 2025 の CFP応募要項です',
+  }}
+>
+  <div class="py-16 md:py-20 mx-4">
+    <div class="text-3xl md:text-4xl font-bold leading-tighter tracking-tighter mb-12 text-center max-w-3xl mx-auto">
+      <h1>Platform Engineering Kaigi 2025へようこそ！</h1>
+    </div>
+
+    <div class="max-w-3xl mx-auto">
+      <p>
+        このイベントは、現在急速に注目を浴びつつあるPlatform Engineeringについて、
+        <strong>学んで、共有して、技術交流を行っていく</strong>ことを目的としています。
+      </p>
+      <br />
+      <p>
+        Platform Engineeringとは、クラウドネイティブ時代において、
+        ソフトウェアエンジニアリング組織にセルフサービス機能を提供するための
+        ツールチェーンやワークフローを設計・構築する技術分野です。
+      </p>
+      <br />
+      <p>
+        Gartnerが発表した
+        <a
+          href="https://www.gartner.com/en/articles/gartner-top-10-strategic-technology-trends-for-2025"
+          >2025年トップ10の戦略的テクノロジートレンド</a
+        >
+        にも登場しており、5年以内にソフトウェアエンジニアリング組織の80%が
+        採用するだろうとも予測されています。
+      </p>
+      <br />
+      <p>
+        とはいえ、こういった新しい技術分野あるあるですが、
+        一体なにがどうなればPlatform Engineeringなのか、ぱっと分かりづらいですよね？
+        これまであったDevOpsなどとどう違うのか、どう関連しているのかも分かりづらいかもしれません。
+      </p>
+      <br />
+      <p>
+        そのために必要なのは、先人に学び、情報交換し、自らも発信していくという営みです。 
+        Platform Engineering Kaigi 2025では、そんな場を一緒に作っていただける方を募集しています。
+      </p>
+      <br />
+      <br />
+      <p>以下のようなカテゴリを設けており、たとえばこのような発表をお待ちしております。</p>
+      <ul class="list-disc ml-8 mt-2">
+        <li>
+          <strong>Tech</strong>
+          <ul class="list-disc ml-6">
+            <li>課題を解決する個別技術</li>
+          </ul>
+        </li>
+        <li>
+          <strong>Blueprints</strong>
+          <ul class="list-disc ml-6">
+            <li>プラットフォームの構想や全体像</li>
+          </ul>
+        </li>
+        <li>
+          <strong>Stories</strong>
+          <ul class="list-disc ml-6">
+            <li>プラットフォームエンジニアリングの実践事例</li>
+          </ul>
+        </li>
+        <li>
+          <strong>Culture</strong>
+          <ul class="list-disc ml-6">
+            <li>開発者にプラットフォームを定着させる文化</li>
+          </ul>
+        </li>
+        <li>
+          <strong>Impact</strong>
+          <ul class="list-disc ml-6">
+            <li>ビジネスへの影響と訴求</li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+
+    <div class="max-w-3xl mx-auto">
+      <div
+        class="text-2xl md:text-3xl font-bold leading-tighter tracking-tighter mt-12 mb-2 text-center max-w-3xl mx-auto"
+      >
+        <h2>スケジュール</h2>
+      </div>
+      <div class="max-w-3xl mx-auto">
+        <ul class="list-disc ml-8">
+          <li>2025/03/xx (金) CFP開始</li>
+          <li>2025/04/xx (金) 23:59 CFP締め切り</li>
+          <li>2025/05/xx 選考結果をご連絡</li>
+          <li>2025/09/18 (木) Platform Engineering Kaigi 2025開催</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="max-w-3xl mx-auto">
+      <div
+        class="text-2xl md:text-3xl font-bold leading-tighter tracking-tighter mt-12 mb-2 text-center max-w-3xl mx-auto"
+      >
+        <h2>登壇方法</h2>
+      </div>
+      <div class="max-w-3xl mx-auto">
+        <ul class="list-disc ml-8">
+          <li>
+            以下よりお選びください
+            <ul class="list-disc ml-6">
+              <li>現地会場（中野セントラルパークカンファレンス）での登壇</li>
+              <li>事前録画の放映</li>
+            </ul>
+          </li>
+          <li>セッション時間はQA含めて30分です</li>
+          <li>
+            セッションは日本語でも英語でも応募可能です
+            <ul class="list-disc ml-6">
+              <li>英語の場合翻訳はつきません。あらかじめご了承ください</li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+
+      <div class="max-w-3xl mx-auto">
+        <div
+          class="text-2xl md:text-3xl font-bold leading-tighter tracking-tighter mt-12 mb-2 text-center max-w-3xl mx-auto"
+        >
+          <h2>エントリーの流れ</h2>
+        </div>
+        <div class="max-w-3xl mx-auto">
+          <p>
+            募集は
+            <a
+              href="https://link.cnia.io/pek2025-cfp-application-form"
+              class="underline-link"
+              >fortee</a
+            >
+            上で行います。
+          </p>
+          <ol class="list-decimal list-inside ml-4 mt-2">
+            <li>forteeのユーザ登録を行ってください。</li>
+            <li>fortee上でスピーカー登録を行い、登壇内容のエントリーを完了させてください。</li>
+            <li>委員会による選考が行われます。選考には数週間かかる場合があります。</li>
+            <li>fortee経由で選考結果がご連絡されます。選考結果は個別にメールでお知らせいたします。</li>
+          </ol>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex flex-col items-center justify-center pt-8">
+      CFPは終了しました。ご応募いただき、ありがとうございました。
+    </div>
+
+    <div class="max-w-3xl mx-auto">
+      <div
+        class="text-2xl md:text-3xl font-bold leading-tighter tracking-tighter mt-12 mb-2 text-center max-w-3xl mx-auto"
+      >
+        <h2>その他留意事項</h2>
+      </div>
+      <div class="max-w-3xl mx-auto">
+        <ul class="list-disc ml-8">
+          <li>
+            1人で複数の応募が可能です
+            <ul class="list-disc ml-6">
+              <li>複数採択されることはありません</li>
+            </ul>
+          </li>
+          <li>複数名での応募が可能です</li>
+          <li>
+            スライドと動画アーカイブの公開可否は選択可能ですが、動画アーカイブNGでも当日の講演内容をライブ配信させていただきます
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="max-w-3xl mx-auto">
+      <div
+        class="text-2xl md:text-3xl font-bold leading-tighter tracking-tighter mt-12 mb-2 text-center max-w-3xl mx-auto"
+      >
+        <h2>お問い合わせ</h2>
+      </div>
+      <div class="max-w-3xl mx-auto">
+        <p>
+          CFPに関するお問い合わせは
+          <a
+            href="https://link.cnia.io/pek2025-cfp-inquiry-form"
+            class="underline-link"
+            >フォーム</a
+          >
+          よりお願いいたします
+        </p>
+      </div>
+    </div>
+
+    <style>
+      .underline-link {
+        text-decoration: underline;
+      }
+
+      .btn.btn-flat {
+        overflow: hidden;
+        padding: 1rem 4rem;
+        color: #fff;
+        border-radius: 0;
+        background: var(--aw-themeColor-blue);
+        position: relative;
+        z-index: 1;
+      }
+
+      .btn.btn-flat span {
+        position: relative;
+      }
+
+      .btn.btn-flat:before {
+        position: absolute;
+        top: 0;
+        left: 30px;
+        width: 150%;
+        height: 500%;
+        content: '';
+        -webkit-transition: all 0.5s ease-in-out;
+        transition: all 0.5s ease-in-out;
+        -webkit-transform: translateX(-85%) translateY(-70%) rotate(135deg);
+        transform: translateX(-85%) translateY(-70%) rotate(135deg);
+        background: var(--aw-themeColor-yellow);
+        z-index: -1;
+      }
+
+      .btn.btn-flat:hover:before {
+        -webkit-transform: translateX(-15%) translateY(-25%) rotate(135deg);
+        transform: translateX(-15%) translateY(-25%) rotate(135deg);
+      }
+
+      .btn.btn-flat:hover {
+        color: #000;
+      }
+    </style>
+  </div>
+</Layout>


### PR DESCRIPTION
このプルリクエストでは、以下の変更を行いました：

1. **ヘッダーリンクの修正**: `Header.astro` コンポーネント内のナビゲーションリンクのURLをアンカーリンクから絶対パスに修正しました。
   - 概要リンク: `href="#about"` から `href="/pek2025#about"` に変更
   - スポンサー募集リンク: `href="#sponsors"` から `href="/pek2025#sponsors"` に変更

2. **新しいページの追加**: `guidance.astro` ページを新たに作成し、「PEK2025 CFP応募要項」に関する詳細な情報を追加しました。このページでは、イベントの目的やプラットフォームエンジニアリングについての説明、スケジュール、登壇方法、エントリーの流れ、留意事項、そして問い合わせ方法を網羅しています。

これにより、PEK2025に関する情報をより明確にし、参加者が必要な詳細を easily 知ることができるようになります。