### PR TITLE
Cloudflare Pagesの自動ビルド設定

### DIFF
--- a/.github/workflows/trigger-cloudflare-pages.yml
+++ b/.github/workflows/trigger-cloudflare-pages.yml
@@ -1,0 +1,15 @@
+name: Scheduled Cloudflare Pages Rebuild
+
+on:
+  schedule:
+    - cron: '0 * * * *'  # 毎時0分（1時間に1回）に実行
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Cloudflare Pages deployment
+        run: |
+          curl -X POST "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/pages/projects/${{ secrets.CLOUDFLARE_PROJECT_NAME }}/deployments" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+            -H "Content-Type: multipart/form-data"


### PR DESCRIPTION
このプルリクエストでは、Cloudflare Pagesのデプロイを定期的にトリガーする GitHub Actions ワークフローを新たに追加しました。
具体的には、毎時0分に自動的にデプロイを実行する設定が含まれています。
デプロイのリクエストは、指定されたCloudflareアカウントとプロジェクトに対して行われ、必要な認証情報はGitHubのシークレットから取得します。