### PR TITLE
Cloudflare Pages のデプロイメントトリガーの環境設定

### DIFF
--- a/.github/workflows/trigger-cloudflare-pages.yml
+++ b/.github/workflows/trigger-cloudflare-pages.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   trigger:
     runs-on: ubuntu-latest
+    environment:
+      name: cloudflare-api
     steps:
       - name: Trigger Cloudflare Pages deployment
         run: |


### PR DESCRIPTION
このプルリクエストでは、GitHub Actions のワークフローファイルである `trigger-cloudflare-pages.yml` に新たに環境設定を追加しました。具体的には、デプロイメントを行うジョブに対して「cloudflare-api」という環境名を指定しています。