### PR TITLE
スポンサー募集リンクの削除

### DIFF
--- a/src/components/pek2025/Footer.astro
+++ b/src/components/pek2025/Footer.astro
@@ -15,9 +15,6 @@ import { Icon } from 'astro-icon/components';
             <li>
               <a href="/pek2025#about" class="hover:text-pek2025-primary-200">概要</a>
             </li>
-            <li>
-              <a href="/pek2025#sponsors" class="hover:text-pek2025-primary-200">スポンサー募集</a>
-            </li>
           </ul>
         </div>
         <div>

--- a/src/components/pek2025/Header.astro
+++ b/src/components/pek2025/Header.astro
@@ -20,9 +20,6 @@ import logoHorizontal from '../../assets/pek2025/logo_horizontal_transparent.png
       <a href="/pek2025#about" class="text-pek2025-primary-700 hover:text-pek2025-primary-600 font-medium">
         概要
       </a>
-      <a href="/pek2025#sponsors" class="text-pek2025-primary-700 hover:text-pek2025-primary-600 font-medium">
-        スポンサー募集
-      </a>
       <a href="/pek2025/sessions" class="text-pek2025-primary-700 hover:text-pek2025-primary-600 font-medium">
         プロポーザル一覧
       </a>


### PR DESCRIPTION
このPRでは、ヘッダーとフッターから既にリンク先が存在していないスポンサー募集のリンクを削除しています。
スポンサー募集は既に終了しているため、削除しても問題なさそうです。

ref: https://pfemjp.slack.com/archives/C08V8BXFP2M/p1749119987737199

| | Header | Footer |
| ---- | ---- | ---- |
| Before | <img width="1356" alt="Screenshot 2025-06-05 at 20 27 32" src="https://github.com/user-attachments/assets/6c911f7b-608d-4905-8904-d1d1d8a42308" /> | <img width="208" alt="Screenshot 2025-06-05 at 20 27 39" src="https://github.com/user-attachments/assets/80fd49a8-0356-4b65-9778-e9fdb8123142" /> |
| After | <img width="1300" alt="Screenshot 2025-06-05 at 20 27 48" src="https://github.com/user-attachments/assets/19435ce1-6111-44de-b301-9b5f22767d11" /> | <img width="197" alt="Screenshot 2025-06-05 at 20 27 53" src="https://github.com/user-attachments/assets/59768f7b-e0dd-4796-9219-8cbdec349c06" /> |





