### PR TITLE
スタッフ紹介のグリッド調整

### DIFF
--- a/src/components/pek2025/TeamMemberList.astro
+++ b/src/components/pek2025/TeamMemberList.astro
@@ -120,7 +120,7 @@ const teamMemberList = [
     <p class="text-base text-200 tracking-wide uppercase mb-1">meet the team</p>
     <h2 class="text-4xl md:text-5xl font-bold leading-tighter tracking-tighter mb-4">スタッフ紹介</h2>
   </div>
-  <div class="grid grid-cols-4 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 max-w-7xl mx-auto">
+  <div class="grid grid-cols-4 sm:grid-cols-5 md:grid-cols-7 lg:grid-cols-9 max-w-7xl mx-auto">
     {
       teamMemberList.map((member) => (
         <TeamMemberInfo


### PR DESCRIPTION
このPRでは、 #162 で作成したスタッフ紹介の微修正を行なっています。
具体的には、PC画面でアイコン画像が大きすぎるため、グリッド列数を増加させています。

Before: https://add-staff-section.cnia-io.pages.dev/pek2025/

After: 