### PR TITLE
ハンバーガーメニューの追加

### DIFF
--- a/src/assets/styles/pek2025/base.css
+++ b/src/assets/styles/pek2025/base.css
@@ -48,3 +48,29 @@
 .font-sans {
   font-family: 'Noto Sans JP', sans-serif;
 }
+
+/* Hamburger menu styles */
+.dropdown:hover .dropdown-menu {
+  display: block;
+}
+
+[data-aw-toggle-menu] path {
+  @apply transition;
+}
+
+[data-aw-toggle-menu].expanded g > path:first-child {
+  @apply -rotate-45 translate-y-[15px] translate-x-[-3px];
+}
+
+[data-aw-toggle-menu].expanded g > path:last-child {
+  @apply rotate-45 translate-y-[-8px] translate-x-[14px];
+}
+
+/* Mobile menu overlay styles */
+#header.h-screen {
+  @apply fixed inset-0 bg-white dark:bg-gray-900 z-50;
+}
+
+#header.h-screen nav {
+  @apply flex flex-col justify-center items-center h-full;
+}

--- a/src/assets/styles/pek2025/base.css
+++ b/src/assets/styles/pek2025/base.css
@@ -66,11 +66,6 @@
   @apply rotate-45 translate-y-[-8px] translate-x-[14px];
 }
 
-/* Mobile menu overlay styles */
-#header.h-screen {
-  @apply fixed inset-0 bg-white dark:bg-gray-900 z-50;
-}
-
-#header.h-screen nav {
-  @apply flex flex-col justify-center items-center h-full;
+#header.scroll {
+  @apply shadow-md md:shadow-md bg-pek2025-background md:backdrop-blur-sm dark:bg-slate-900;
 }

--- a/src/components/common/ToggleMenu.astro
+++ b/src/components/common/ToggleMenu.astro
@@ -18,5 +18,5 @@ const {
 ---
 
 <button type="button" class={className} aria-label={label} data-aw-toggle-menu>
-  <Icon name={iconName} class={iconClass} optimize={false} />
+  <Icon name={iconName} class={iconClass} />
 </button>

--- a/src/components/pek2025/Header.astro
+++ b/src/components/pek2025/Header.astro
@@ -21,7 +21,9 @@ const links = [
         </a>
       </div>
       <div class="flex items-center md:hidden">
-        <ToggleMenu />
+        <ToggleMenu
+          class="ml-1.5 text-pek2025-primary hover:bg-pek2025-primary-100 focus:outline-none focus:ring-pek2025-primary-200 rounded-lg text-sm p-2.5 inline-flex items-center transition"
+        />
       </div>
     </div>
     <nav

--- a/src/components/pek2025/Header.astro
+++ b/src/components/pek2025/Header.astro
@@ -2,21 +2,48 @@
 // Props can be added here if needed in the future
 import { Image } from 'astro:assets';
 import logoHorizontal from '../../assets/pek2025/logo_horizontal_transparent.png';
+import ToggleMenu from '~/components/common/ToggleMenu.astro';
+import { getPermalink } from '~/utils/permalinks';
+
+const links = [
+  { text: 'ホーム', href: getPermalink('/pek2025') },
+  { text: 'プロポーザル一覧', href: getPermalink('/pek2025/sessions') },
+  { text: 'ブログ', href: getPermalink('/pek2025/blog') },
+];
 ---
 
-<header class="container mx-auto pt-4 px-4">
-  <div class="flex justify-between items-center">
-    <div class="flex items-center">
-      <a href="/pek2025" class="mr-6">
-        <Image src={logoHorizontal} alt="PEK2025 Logo" width={150} class="h-15 w-auto" />
-      </a>
+<header class="container mx-auto pt-4 px-4" id="header">
+  <div class="w-full md:flex md:justify-between max-w-7xl">
+    <div class="flex justify-between">
+      <div class="flex items-center">
+        <a href="/pek2025" class="mr-6">
+          <Image src={logoHorizontal} alt="PEK2025 Logo" width={150} class="h-15 w-auto" />
+        </a>
+      </div>
+      <div class="flex items-center md:hidden">
+        <ToggleMenu />
+      </div>
     </div>
-    <nav class="flex space-x-6">
-      <a href="/pek2025#about" class="text-pek2025-primary-700 hover:text-pek2025-primary-600 font-medium"> 概要 </a>
-      <a href="/pek2025/sessions" class="text-pek2025-primary-700 hover:text-pek2025-primary-600 font-medium">
-        プロポーザル一覧
-      </a>
-      <a href="/pek2025/blog" class="text-pek2025-primary-700 hover:text-pek2025-primary-600 font-medium"> ブログ </a>
+    <nav
+      class="w-full md:w-auto hidden md:flex h-[calc(100vh-72px)] md:h-auto overflow-y-auto md:overflow-visible"
+      aria-label="Main navigation"
+    >
+      <ul
+        class="flex flex-col pt-8 md:pt-0 md:flex-row md:self-center w-full md:w-auto text-base space-y-4 md:space-y-0 md:space-x-6"
+      >
+        {
+          links.map(({ text, href }) => (
+            <li>
+              <a
+                href={href}
+                class="text-pek2025-primary-700 hover:text-pek2025-primary-600 font-medium block px-4 py-3 md:px-0 md:py-0"
+              >
+                {text}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
     </nav>
   </div>
 </header>

--- a/src/layouts/pek2025/BaseLayout.astro
+++ b/src/layouts/pek2025/BaseLayout.astro
@@ -1,5 +1,5 @@
 ---
-import './styles.css';
+import '~/assets/styles/pek2025/base.css';
 import CustomStyles from '~/components/CustomStyles.astro';
 import BasicScripts from '~/components/common/BasicScripts.astro';
 import { SITE } from '~/config.mjs';


### PR DESCRIPTION
このPRでは、画面サイズが小さい時にヘッダーをハンバーガーメニューに変化させるように変更しました。画面サイズが大きい時のデザインに変更はありません。
また、`src/layouts/pek2025`に配置されていたCSSファイルを、PEK2024と同様に`src/assets/styles`以下に移動させました。

| Before | After |
|--|--|
| ![cnia-io pages dev_pek2025_(iPhone XR)](https://github.com/user-attachments/assets/0256ceec-b158-4427-ad1e-4ced81c91b18) | ![add-hamburger-menu cnia-io pages dev_pek2025_(iPhone XR) (4)](https://github.com/user-attachments/assets/7604c4df-09da-4342-821c-91b2ec130669)  |
| | ![add-hamburger-menu cnia-io pages dev_pek2025_(iPhone XR) (3)](https://github.com/user-attachments/assets/3135d03f-d297-4f03-b999-a564af69428a) |






